### PR TITLE
feat(matrix): extend sourceId related bits

### DIFF
--- a/src/main/scala/coupledL2/Common.scala
+++ b/src/main/scala/coupledL2/Common.scala
@@ -43,7 +43,7 @@ trait HasTLChannelBits { this: Bundle =>
 
 trait HasAMEBits { this: Bundle =>
   val ameChannel = UInt(4.W)  // Assume 8 channels, additional 1 bit for invalid value.
-  val ameIndex = UInt(5.W)
+  val ameIndex = UInt(7.W)
 }
 
 class MergeTaskBundle(implicit p: Parameters) extends L2Bundle {
@@ -57,7 +57,7 @@ class MergeTaskBundle(implicit p: Parameters) extends L2Bundle {
   val meta = new MetaEntry()
 }
 class MatrixDataBundle(implicit p: Parameters) extends L2Bundle {
-  val sourceId = UInt(5.W)     // tilelink sourceID(32)
+  val sourceId = UInt(7.W)     // tilelink sourceID (64) + 1 (cover 64)
   val data = new DSBlock()
   val channel = UInt(3.W)
 }

--- a/src/main/scala/coupledL2/L2Param.scala
+++ b/src/main/scala/coupledL2/L2Param.scala
@@ -73,7 +73,7 @@ case object AmeChannelKey extends ControlKey[UInt](name = "AmeChannel")
 case class AmeChannelField() extends BundleField[UInt](AmeChannelKey, Output(UInt(4.W)), _ := 0.U(4.W))
 
 case object AmeIndexKey extends ControlKey[UInt](name = "AmeIndex")
-case class AmeIndexField() extends BundleField[UInt](AmeIndexKey, Output(UInt(5.W)), _ := 0.U(5.W))
+case class AmeIndexField() extends BundleField[UInt](AmeIndexKey, Output(UInt(7.W)), _ := 0.U(7.W))
 
 case class L2Param(
   name: String = "L2",


### PR DESCRIPTION
To fit new devices' source range requirements.