### PR TITLE
feat(Put): Complete PutFullData Request Flow Implementation for TL-TL and TL-CHI

### DIFF
--- a/src/main/scala/coupledL2/Common.scala
+++ b/src/main/scala/coupledL2/Common.scala
@@ -115,10 +115,6 @@ class TaskBundle(implicit p: Parameters) extends L2Bundle
   // For DirtyKey in Release
   val dirty = Bool()
 
-  // TL-to-TL compatibility fields. TL-to-CHI PutBuffer path must not carry or select Put payload with them.
-  val putData = new DSBlock()
-  val usePutData = Bool()
-
   // if this is an mshr task and it needs to write dir
   val way = UInt(wayBits.W)
   val meta = new MetaEntry()
@@ -285,6 +281,10 @@ class MSHRInfo(implicit p: Parameters) extends L2Bundle with HasTLChannelBits {
   // to drop duplicate prefetch reqs
   val isAcqOrPrefetch = Bool()
   val isPrefetch = Bool()
+  // True when the original request is an A-channel Put.
+  // We need this field to suppress resp data in TL-RefillUnit or in CHI-RXDAT when future PutPartialData is supported.
+  // Currently consumed only by the TL-to-TL RefillUnit to suppress Put-triggered refill data.
+  val isPut = Bool()
 
   // whether the mshr_task already in mainpipe
   val param = UInt(3.W)

--- a/src/main/scala/coupledL2/Common.scala
+++ b/src/main/scala/coupledL2/Common.scala
@@ -91,7 +91,8 @@ class TaskBundle(implicit p: Parameters) extends L2Bundle
   val param = UInt(3.W)
   val size = UInt(msgSizeBits.W)
   val sourceId = UInt(sourceIdBits.W)     // tilelink sourceID
-  val bufIdx = UInt(bufIdxBits.W)         // idx of SinkC buffer
+
+  val bufIdx = UInt(bufIdxBits.W)         // Shared sink buffer index. SinkC uses it for dataBuf, and SinkA uses it for PutBuffer.
   val needProbeAckData = Bool()           // only used for SinkB reqs, whether L3 needs probeAckData
   val denied = Bool()
   val corrupt = Bool()
@@ -114,7 +115,7 @@ class TaskBundle(implicit p: Parameters) extends L2Bundle
   // For DirtyKey in Release
   val dirty = Bool()
 
-  // Matrix PutFullData hit support. Only full-line Put data is carried here.
+  // TL-to-TL compatibility fields. TL-to-CHI PutBuffer path must not carry or select Put payload with them.
   val putData = new DSBlock()
   val usePutData = Bool()
 

--- a/src/main/scala/coupledL2/PutBuffer.scala
+++ b/src/main/scala/coupledL2/PutBuffer.scala
@@ -1,0 +1,87 @@
+package coupledL2
+
+import chisel3._
+import chisel3.util._
+import chisel3.experimental.BundleLiterals._
+import org.chipsalliance.cde.config.Parameters
+
+class PutBufState(implicit p: Parameters) extends L2Bundle {
+  val entryIdx = UInt(bufIdxBits.W)
+}
+
+class PutBufWrite(implicit p: Parameters) extends L2Bundle {
+  val data = UInt((beatBytes * 8).W)
+  val beat = UInt(beatBits.W)
+  val last = Bool()
+}
+
+class PutBufRead(implicit p: Parameters) extends L2Bundle {
+  val id = UInt(bufIdxBits.W)
+}
+
+class PutBufResp(implicit p: Parameters) extends L2Bundle {
+  val data = new DSBlock
+}
+
+class PutBuffer(implicit p: Parameters) extends L2Module {
+  // ------------------------------------------ IO Declaration ------------------------------------------ //
+  val io = IO(new Bundle {
+    // Read and write requests
+    val w     = Flipped(DecoupledIO(new PutBufWrite)) // write request from SinkA
+    val r     = Flipped(ValidIO(new PutBufRead))      // read request from RequestArb
+
+    val state = Output(new PutBufState) // PutBuffer state exposed to SinkA for task allocation
+
+    val resp  = Output(new PutBufResp)  // Block-level read response to MainPipe s3
+    
+  })
+
+  // ------------------------------------------ Wire/Reg Declaration ------------------------------------ //
+  private val buffer = RegInit(
+    VecInit(
+      Seq.fill(bufBlocks)
+        (Valid(Vec(beatSize, UInt((beatBytes * 8).W))).Lit(_.valid -> false.B))
+    )
+  )
+
+  private val valids   = VecInit(buffer.map(_.valid))
+  private val full     = valids.asUInt.andR
+  private val freeMask = ~valids.asUInt
+  private val sel      = PriorityEncoder(freeMask)
+
+  // ------------------------------------------ Main Logic ----------------------------------------- /
+  // Write logic
+  buffer.zipWithIndex.foreach { case (entry, i) =>
+    val wen = io.w.fire && sel === i.U
+    val readThis = io.r.valid && io.r.bits.id === i.U
+
+    when (wen) {
+      entry.bits(io.w.bits.beat) := io.w.bits.data
+
+      when (io.w.bits.last) {
+        entry.valid := true.B
+      }
+    }
+  }
+  
+  // read logic
+  when (io.r.valid) {
+    buffer(io.r.bits.id).valid := false.B
+  }
+
+  private val rdata = RegEnable(
+    buffer(io.r.bits.id).bits.asUInt,
+    0.U(blockBits.W),
+    io.r.valid
+  )
+
+  // ------------------------------------------ IO Assignment ------------------------------------- //
+  io.state.entryIdx := sel
+  io.w.ready        := !full
+  io.resp.data.data := rdata
+
+  // ------------------------------------------ Dont Touch ------------------------------------- //
+  dontTouch(freeMask)
+  dontTouch(full)
+  dontTouch(sel)
+}

--- a/src/main/scala/coupledL2/PutBuffer.scala
+++ b/src/main/scala/coupledL2/PutBuffer.scala
@@ -10,9 +10,10 @@ class PutBufState(implicit p: Parameters) extends L2Bundle {
 }
 
 class PutBufWrite(implicit p: Parameters) extends L2Bundle {
-  val data = UInt((beatBytes * 8).W)
-  val beat = UInt(beatBits.W)
-  val last = Bool()
+  val data  = UInt((beatBytes * 8).W)
+  val beat  = UInt(beatBits.W)
+  val first = Bool()
+  val last  = Bool()
 }
 
 class PutBufRead(implicit p: Parameters) extends L2Bundle {
@@ -47,10 +48,21 @@ class PutBuffer(implicit p: Parameters) extends L2Module {
   private val valids   = VecInit(buffer.map(_.valid))
   private val full     = valids.asUInt.andR
   private val freeMask = ~valids.asUInt
-  private val sel      = PriorityEncoder(freeMask)
+
+  // In PutBuffer, the selected entry MUST BE held in a register.
+  // It cannot dynamically compute sel with PriorityEncoder every cycle like RequestBuffer.
+  // This is because PutBuffer performs multi-beat writes. If sel is dynamically computed every cycle,
+  // different beats of the same write may be written into different entries. For example:
+  // cycle 0: sel = 1, write beat 0 to entry 1
+  // also in cycle 0: data in entry 0 is consumed, entry 0 becomes free
+  // cycle 1: Because of the priority of entry 0 is higher than entry 1, sel = 0, write beat 1 to entry 0 -> Data Mismatch!
+  private val sel_r    = RegInit(0.U(bufIdxBits.W))
+  private val sel_nxt  = PriorityEncoder(freeMask)
+
+  private val sel = Mux(io.w.bits.first, sel_nxt, sel_r)
 
   // ------------------------------------------ Main Logic ----------------------------------------- /
-  // Write logic
+  /* Write logic */
   buffer.zipWithIndex.foreach { case (entry, i) =>
     val wen = io.w.fire && sel === i.U
     val readThis = io.r.valid && io.r.bits.id === i.U
@@ -63,25 +75,31 @@ class PutBuffer(implicit p: Parameters) extends L2Module {
       }
     }
   }
+
+  // Store the selected entry when the **FIRST** beat fires.
+  // DO NOT update sel_r on the last beat: the current entry may be the last free entry,
+  // so selecting a new entry at that point may produce an invalid or meaningless result
+  // and cause subsequent writes to use the wrong entry.
+  when (io.w.fire && io.w.bits.first) {
+    sel_r := sel_nxt
+  }
   
   // read logic
   when (io.r.valid) {
     buffer(io.r.bits.id).valid := false.B
   }
 
-  private val rdata = RegEnable(
-    buffer(io.r.bits.id).bits.asUInt,
-    0.U(blockBits.W),
-    io.r.valid
-  )
+  private val rdata = RegEnable(buffer(io.r.bits.id).bits.asUInt, io.r.valid)
 
   // ------------------------------------------ IO Assignment ------------------------------------- //
-  io.state.entryIdx := sel
+  io.state.entryIdx := sel_r
   io.w.ready        := !full
   io.resp.data.data := rdata
 
   // ------------------------------------------ Dont Touch ------------------------------------- //
   dontTouch(freeMask)
   dontTouch(full)
+  dontTouch(sel_r)
+  dontTouch(sel_nxt)
   dontTouch(sel)
 }

--- a/src/main/scala/coupledL2/RequestArb.scala
+++ b/src/main/scala/coupledL2/RequestArb.scala
@@ -49,7 +49,10 @@ class SteerS2ToS3 extends Bundle {
   val sinkCDataRead  = Bool() // SinkC dataBuffer read in s2
 
   def assertOH: Unit = {
-    val issuedVec = Seq(refillBufRead, releaseBufRead, putBufRead, sinkCDataRead)
+    // TODO: Make this assertion more precise.
+    // This assertion is intentionally relaxed for now: refillBufRead and releaseBufRead
+    // may be asserted in the same S2 cycle for an MSHR release task in the tl2tl branch.
+    val issuedVec = Seq(refillBufRead || releaseBufRead, putBufRead, sinkCDataRead)
     assert(PopCount(VecInit(issuedVec)) <= 1.U, "Multiple data source read req issued in the same cycle!")
   }
 }

--- a/src/main/scala/coupledL2/RequestArb.scala
+++ b/src/main/scala/coupledL2/RequestArb.scala
@@ -86,7 +86,7 @@ class RequestArb(implicit p: Parameters) extends L2Module
     val refillBufRead_s2 = ValidIO(new MSHRBufRead)
     val releaseBufRead_s2 = ValidIO(new MSHRBufRead)
     /* send channel task dataBuf read request */
-    val putBufRead_s2 = ValidIO(Bool()) // Read SinkA PutBuffer TODO: Not Bool()
+    val putBufRead_s2 = ValidIO(new PutBufRead) // read sinkA putBuf
 
     /* status of each pipeline stage */
     val status_s1 = Output(new PipeEntranceStatus) // set & tag of entrance status
@@ -126,13 +126,11 @@ class RequestArb(implicit p: Parameters) extends L2Module
   val s2_ready  = Wire(Bool())
   val mshr_task_s1 = RegInit(0.U.asTypeOf(Valid(new TaskBundle())))
 
-  // Jiang: 此处 s1_put_install 是不需要的
-  val s1_put_install = mshr_task_s1.bits.opcode === AccessAck && mshr_task_s1.bits.usePutData
   val s1_needs_replRead = mshr_task_s1.valid && mshr_task_s1.bits.fromA && mshr_task_s1.bits.replTask && (
-    mshr_task_s1.bits.opcode === Grant ||
-    mshr_task_s1.bits.opcode === GrantData ||
+    mshr_task_s1.bits.opcode === Grant         ||
+    mshr_task_s1.bits.opcode === GrantData     ||
     mshr_task_s1.bits.opcode === AccessAckData ||
-    s1_put_install ||
+    mshr_task_s1.bits.opcode === AccessAck     || // For MSHR Task caused by Put.
     mshr_task_s1.bits.opcode === HintAck
   )
 
@@ -142,9 +140,6 @@ class RequestArb(implicit p: Parameters) extends L2Module
   assert(!s1_needs_replRead || mshr_task_s1.bits.opcode =/= AccessAckData || mshr_task_s1.bits.dsWen,
     "replTask of AccessAckData with no DataStorage write was not expected")
 
-  assert(!s1_needs_replRead || mshr_task_s1.bits.opcode =/= AccessAck || !mshr_task_s1.bits.usePutData || mshr_task_s1.bits.dsWen,
-    "replTask of AccessAck Put install with no DataStorage write was not expected")
-  
   assert(!s1_needs_replRead || mshr_task_s1.bits.opcode =/= HintAck || mshr_task_s1.bits.dsWen,
     "replTask of HintAck with no DataStorage write was not expected")
 
@@ -259,12 +254,14 @@ class RequestArb(implicit p: Parameters) extends L2Module
   // MSHR task
   val mshrTask_s2 = task_s2.valid && task_s2.bits.mshrTask
   val mshrTask_s2_a_upwards = task_s2.bits.fromA &&
-    (task_s2.bits.opcode === GrantData || task_s2.bits.opcode === Grant && task_s2.bits.dsWen ||
-      task_s2.bits.opcode === AccessAckData || task_s2.bits.opcode === HintAck && task_s2.bits.dsWen)
+    ( task_s2.bits.opcode === GrantData     || 
+      task_s2.bits.opcode === Grant         && task_s2.bits.dsWen ||
+      task_s2.bits.opcode === AccessAck     || // for mshr grant task caused by put
+      task_s2.bits.opcode === AccessAckData || 
+      task_s2.bits.opcode === HintAck       && task_s2.bits.dsWen)
   // For GrantData, read refillBuffer
   // Caution: GrantData-alias may read DataStorage or ReleaseBuf instead
   // Release-replTask normally reads refillBuf and writes that data into DS.
-  // Replacement-safe PutFullData install carries its final DS data in-task instead.
   val releaseRefillData = task_s2.bits.replTask && !task_s2.bits.usePutData && (if (enableCHI) {
     task_s2.bits.toTXREQ && (
       task_s2.bits.chiOpcode.get === WriteBackFull ||
@@ -318,8 +315,10 @@ class RequestArb(implicit p: Parameters) extends L2Module
   // **Always** read PutBuffer for PutFullData tasks because their payload is guaranteed to be consumed in s3:
   // it is either written directly to DS or moved into RefillBuffer for later MSHR handling.
   // After s3, PutBuffer no longer owns the payload.
-  io.putBufRead_s2.valid := task_s2.valid && task_s2.bits.opcode === PutFullData
-  // TODO: io.putBufRead_s2.valid.bits assignments.
+  // PutFullData is enough to identify the original SinkA Put task: MSHR tasks get a reallocated opcode 'AccessAck' and
+  // cannot still be 'PutFullData'.
+  io.putBufRead_s2.valid   := task_s2.valid && task_s2.bits.opcode === PutFullData
+  io.putBufRead_s2.bits.id := task_s2.bits.bufIdx
 
   /* s2 steer signals to s3 */
   private val steer_s2 = RegInit(0.U.asTypeOf(io.steerToPipe_s2))

--- a/src/main/scala/coupledL2/RequestArb.scala
+++ b/src/main/scala/coupledL2/RequestArb.scala
@@ -26,8 +26,38 @@ import org.chipsalliance.cde.config.Parameters
 import coupledL2.tl2tl._
 import coupledL2.tl2chi._
 
+/*
+ * SteerS2ToS3 carries local pipeline steering metadata from RequestArb s2 to MainPipe s3.
+ * Each bit records that s2 has issued a non-blocking read to one task data source.
+ * Those sources return data in the next cycle, so s3 can identify which returned data
+ * is meaningful without re-deriving the same intent from opcode, channel, and task attributes.
+ *
+ * Keep this bundle limited to semantic facts already resolved in s2 and consumed in s3.
+ * It improves readability and timing by avoiding duplicated decode logic in s3, but it
+ * must not become a replacement for the full read-issue or DS write-enable conditions.
+ *
+ * Task data sources include:
+ * - RefillBuffer
+ * - ReleaseBuffer
+ * - PutBuffer  in SinkA
+ * - DataBuffer in SinkC (TODO)
+ */
+class SteerS2ToS3 extends Bundle {
+  val refillBufRead  = Bool() // RefillBuffer     read in s2
+  val releaseBufRead = Bool() // ReleaseBuffer    read in s2
+  val putBufRead     = Bool() // SinkA PutBuffer  read in s2
+  val sinkCDataRead  = Bool() // SinkC dataBuffer read in s2
+
+  def assertOH: Unit = {
+    val issuedVec = Seq(refillBufRead, releaseBufRead, putBufRead, sinkCDataRead)
+    assert(PopCount(VecInit(issuedVec)) <= 1.U, "Multiple data source read req issued in the same cycle!")
+  }
+}
+
 class RequestArb(implicit p: Parameters) extends L2Module
   with HasCHIOpcodes {
+
+  require(beatSize == 2)
 
   val io = IO(new Bundle() {
     /* receive incoming tasks */
@@ -49,10 +79,14 @@ class RequestArb(implicit p: Parameters) extends L2Module
     val taskToPipe_s2 = ValidIO(new TaskBundle())
     /* send s1 task info to mainpipe to help hint */
     val taskInfo_s1 = ValidIO(new TaskBundle())
+    /* send s2 steer signals to mainpipe s3 */
+    val steerToPipe_s2 = Output(new SteerS2ToS3)
 
     /* send mshrBuf read request */
     val refillBufRead_s2 = ValidIO(new MSHRBufRead)
     val releaseBufRead_s2 = ValidIO(new MSHRBufRead)
+    /* send channel task dataBuf read request */
+    val putBufRead_s2 = ValidIO(Bool()) // Read SinkA PutBuffer TODO: Not Bool()
 
     /* status of each pipeline stage */
     val status_s1 = Output(new PipeEntranceStatus) // set & tag of entrance status
@@ -92,6 +126,7 @@ class RequestArb(implicit p: Parameters) extends L2Module
   val s2_ready  = Wire(Bool())
   val mshr_task_s1 = RegInit(0.U.asTypeOf(Valid(new TaskBundle())))
 
+  // Jiang: 此处 s1_put_install 是不需要的
   val s1_put_install = mshr_task_s1.bits.opcode === AccessAck && mshr_task_s1.bits.usePutData
   val s1_needs_replRead = mshr_task_s1.valid && mshr_task_s1.bits.fromA && mshr_task_s1.bits.replTask && (
     mshr_task_s1.bits.opcode === Grant ||
@@ -279,7 +314,21 @@ class RequestArb(implicit p: Parameters) extends L2Module
     task_s2.bits.mshrId
   )
 
-  require(beatSize == 2)
+  /* putBuffer read request generation */
+  // **Always** read PutBuffer for PutFullData tasks because their payload is guaranteed to be consumed in s3:
+  // it is either written directly to DS or moved into RefillBuffer for later MSHR handling.
+  // After s3, PutBuffer no longer owns the payload.
+  io.putBufRead_s2.valid := task_s2.valid && task_s2.bits.opcode === PutFullData
+  // TODO: io.putBufRead_s2.valid.bits assignments.
+
+  /* s2 steer signals to s3 */
+  private val steer_s2 = RegInit(0.U.asTypeOf(io.steerToPipe_s2))
+  steer_s2.refillBufRead  := io.refillBufRead_s2 .valid
+  steer_s2.releaseBufRead := io.releaseBufRead_s2.valid
+  steer_s2.putBufRead     := io.putBufRead_s2    .valid
+  steer_s2.sinkCDataRead  := false.B // TODO: currently always false
+
+  io.steerToPipe_s2 := steer_s2
 
   /* status of each pipeline stage */
   io.status_s1.sets := VecInit(Seq(C_task.set, B_task.set, io.ASet, mshr_task_s1.bits.set))

--- a/src/main/scala/coupledL2/RequestArb.scala
+++ b/src/main/scala/coupledL2/RequestArb.scala
@@ -353,6 +353,10 @@ class RequestArb(implicit p: Parameters) extends L2Module
     }
   }
 
+  // Assertions
+  io.steerToPipe_s2.assertOH
+
+  // Don't Touch
   dontTouch(io)
 
   // Performance counters

--- a/src/main/scala/coupledL2/RequestArb.scala
+++ b/src/main/scala/coupledL2/RequestArb.scala
@@ -262,7 +262,7 @@ class RequestArb(implicit p: Parameters) extends L2Module
   // For GrantData, read refillBuffer
   // Caution: GrantData-alias may read DataStorage or ReleaseBuf instead
   // Release-replTask normally reads refillBuf and writes that data into DS.
-  val releaseRefillData = task_s2.bits.replTask && !task_s2.bits.usePutData && (if (enableCHI) {
+  val releaseRefillData = task_s2.bits.replTask && (if (enableCHI) {
     task_s2.bits.toTXREQ && (
       task_s2.bits.chiOpcode.get === WriteBackFull ||
       task_s2.bits.chiOpcode.get === WriteEvictFull ||

--- a/src/main/scala/coupledL2/RequestArb.scala
+++ b/src/main/scala/coupledL2/RequestArb.scala
@@ -317,7 +317,7 @@ class RequestArb(implicit p: Parameters) extends L2Module
   // After s3, PutBuffer no longer owns the payload.
   // PutFullData is enough to identify the original SinkA Put task: MSHR tasks get a reallocated opcode 'AccessAck' and
   // cannot still be 'PutFullData'.
-  io.putBufRead_s2.valid   := task_s2.valid && task_s2.bits.opcode === PutFullData
+  io.putBufRead_s2.valid   := task_s2.valid && task_s2.bits.fromA && !task_s2.bits.mshrTask && task_s2.bits.opcode === PutFullData
   io.putBufRead_s2.bits.id := task_s2.bits.bufIdx
 
   /* s2 steer signals to s3 */

--- a/src/main/scala/coupledL2/SinkA.scala
+++ b/src/main/scala/coupledL2/SinkA.scala
@@ -95,9 +95,6 @@ class SinkA(implicit p: Parameters) extends L2Module {
     task.fromL2pft.foreach(_ := false.B)
     task.needHint.foreach(_ := a.user.lift(PrefetchKey).getOrElse(false.B))
     task.dirty := false.B
-    // TODO: kept only for TL-to-TL compatibility. TL-to-CHI PutBuffer path must not use these fields.
-    task.putData := 0.U.asTypeOf(new DSBlock)
-    task.usePutData := false.B
     task.way := Mux(cmoAllTaskValid, wayVal, 0.U(wayBits.W))
     task.meta := 0.U.asTypeOf(new MetaEntry)
     task.metaWen := false.B
@@ -142,9 +139,6 @@ class SinkA(implicit p: Parameters) extends L2Module {
     task.mshrRetry := false.B
     task.needHint.foreach(_ := false.B)
     task.dirty := false.B
-    // TODO: kept only for TL-to-TL compatibility. TL-to-CHI PutBuffer path must not use these fields.
-    task.putData := 0.U.asTypeOf(new DSBlock)
-    task.usePutData := false.B
     task.way := 0.U(wayBits.W)
     task.meta := 0.U.asTypeOf(new MetaEntry)
     task.metaWen := false.B

--- a/src/main/scala/coupledL2/SinkA.scala
+++ b/src/main/scala/coupledL2/SinkA.scala
@@ -29,17 +29,21 @@ import utility.{MemReqSource, XSPerfAccumulate}
 
 class SinkA(implicit p: Parameters) extends L2Module {
   val io = IO(new Bundle() {
-    val a = Flipped(DecoupledIO(new TLBundleA(edgeIn.bundle)))
+    val a           = Flipped(DecoupledIO(new TLBundleA(edgeIn.bundle)))
     val prefetchReq = prefetchOpt.map(_ => Flipped(DecoupledIO(new PrefetchReq)))
-    val task = DecoupledIO(new TaskBundle)
-    val cmoAll = Option.when(cacheParams.enableL2Flush) (new IOCMOAll)
+    val task        = DecoupledIO(new TaskBundle)
+    
+    // Interface with PutBuffer
+    val pBufState   = Input(new PutBufState)
+    val putBufWrite = DecoupledIO(new PutBufWrite)
+
+    val cmoAll      = Option.when(cacheParams.enableL2Flush) (new IOCMOAll)
   })
   require(beatSize == 2)
   val (a_first, a_last, _, a_beat) = edgeIn.count(io.a)
   val a_putFull = io.a.bits.opcode === PutFullData
   val a_putPartial = io.a.bits.opcode === PutPartialData
   val a_matrixKey = io.a.bits.user.lift(MatrixKey).getOrElse(0.U)
-  val putDataFirst = RegInit(0.U((beatBytes * 8).W))
   val putDataFirstValid = RegInit(false.B)
 
   assert(!(io.a.valid && a_putPartial),
@@ -91,6 +95,7 @@ class SinkA(implicit p: Parameters) extends L2Module {
     task.fromL2pft.foreach(_ := false.B)
     task.needHint.foreach(_ := a.user.lift(PrefetchKey).getOrElse(false.B))
     task.dirty := false.B
+    // TODO: kept only for TL-to-TL compatibility. TL-to-CHI PutBuffer path must not use these fields.
     task.putData := 0.U.asTypeOf(new DSBlock)
     task.usePutData := false.B
     task.way := Mux(cmoAllTaskValid, wayVal, 0.U(wayBits.W))
@@ -137,6 +142,7 @@ class SinkA(implicit p: Parameters) extends L2Module {
     task.mshrRetry := false.B
     task.needHint.foreach(_ := false.B)
     task.dirty := false.B
+    // TODO: kept only for TL-to-TL compatibility. TL-to-CHI PutBuffer path must not use these fields.
     task.putData := 0.U.asTypeOf(new DSBlock)
     task.usePutData := false.B
     task.way := 0.U(wayBits.W)
@@ -159,8 +165,7 @@ class SinkA(implicit p: Parameters) extends L2Module {
   }
   if (prefetchOpt.nonEmpty) {
     val aTask = fromTLAtoTaskBundle(io.a.bits)
-    aTask.putData.data := Cat(io.a.bits.data, putDataFirst)
-    aTask.usePutData := a_putFull
+    aTask.bufIdx := Mux(a_putFull, io.pBufState.entryIdx, 0.U(bufIdxBits.W))
     val aTaskValid = io.a.valid && !cmoAllBlocksA && (!a_putFull || a_last)
     val prefetchCanIssue = !io.a.valid && !putDataFirstValid && !cmoAllTaskValid
     val prefetchTaskValid = io.prefetchReq.get.valid && prefetchCanIssue
@@ -170,19 +175,33 @@ class SinkA(implicit p: Parameters) extends L2Module {
       aTask,
       fromPrefetchReqtoTaskBundle(io.prefetchReq.get.bits
     ))
-    io.a.ready := !cmoAllBlocksA && Mux(a_putFull, Mux(a_last, io.task.ready, true.B), io.task.ready)
     io.prefetchReq.get.ready := io.task.ready && prefetchCanIssue
   } else {
     val aTask = fromTLAtoTaskBundle(io.a.bits)
-    aTask.putData.data := Cat(io.a.bits.data, putDataFirst)
-    aTask.usePutData := a_putFull
+    aTask.bufIdx := Mux(a_putFull, io.pBufState.entryIdx, 0.U(bufIdxBits.W))
     io.task.valid := io.a.valid && !cmoAllBlocksA && (!a_putFull || a_last) || cmoAllTaskValid
     io.task.bits := aTask
-    io.a.ready := !cmoAllBlocksA && Mux(a_putFull, Mux(a_last, io.task.ready, true.B), io.task.ready)
   }
 
+  io.a.ready := !cmoAllBlocksA &&
+      Mux(
+        a_putFull, 
+        Mux(
+          a_last,
+          // On last beat, the selected entry has already been allocated, 
+          // so io.putBufWrite.ready is expected to be true and task ready is the only gate.
+          io.task.ready,
+          io.putBufWrite.ready
+        ), 
+        io.task.ready
+      )
+
+  io.putBufWrite.valid     := io.a.fire && a_putFull
+  io.putBufWrite.bits.data := io.a.bits.data
+  io.putBufWrite.bits.beat := a_beat
+  io.putBufWrite.bits.last := a_last
+
   when (io.a.fire && a_putFull && a_first && !a_last) {
-    putDataFirst := io.a.bits.data
     putDataFirstValid := true.B
   }
   when (io.a.fire && a_putFull && a_last) {

--- a/src/main/scala/coupledL2/SinkA.scala
+++ b/src/main/scala/coupledL2/SinkA.scala
@@ -196,10 +196,11 @@ class SinkA(implicit p: Parameters) extends L2Module {
         io.task.ready
       )
 
-  io.putBufWrite.valid     := io.a.fire && a_putFull
-  io.putBufWrite.bits.data := io.a.bits.data
-  io.putBufWrite.bits.beat := a_beat
-  io.putBufWrite.bits.last := a_last
+  io.putBufWrite.valid      := io.a.fire && a_putFull
+  io.putBufWrite.bits.data  := io.a.bits.data
+  io.putBufWrite.bits.beat  := a_beat
+  io.putBufWrite.bits.first := a_first
+  io.putBufWrite.bits.last  := a_last
 
   when (io.a.fire && a_putFull && a_first && !a_last) {
     putDataFirstValid := true.B

--- a/src/main/scala/coupledL2/tl2chi/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHR.scala
@@ -134,6 +134,9 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
     state     := io.alloc.bits.state
     dirResult := io.alloc.bits.dirResult
     req       := io.alloc.bits.task
+    // TL-to-TL compatibility only; TL-to-CHI PutBuffer flow must not store Put payload in TaskBundle.
+    req.putData := 0.U.asTypeOf(new DSBlock)
+    req.usePutData := false.B
     gotT        := false.B
     gotDirty    := false.B
     gotGrantData := false.B
@@ -734,19 +737,15 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
     mp_grant.isKeyword.foreach(_ := req.isKeyword.getOrElse(false.B))
     mp_grant.opcode := odOpGen(req.opcode)
     mp_grant.param := Mux(
-      req_putfull,
-      0.U,
-      Mux(
-        req_get || req_prefetch,
-        0.U, // Get -> AccessAckData
-        MuxLookup( // Acquire -> Grant
-          req.param,
-          req.param)(
-          Seq(
-            NtoB -> Mux(req_promoteT, toT, toB),
-            BtoT -> toT,
-            NtoT -> toT
-          )
+      req_putfull || req_get || req_prefetch,
+      0.U, // Get, Prefetch -> AccessAckData, Put -> AccessAck
+      MuxLookup( // Acquire -> Grant
+        req.param,
+        req.param)(
+        Seq(
+          NtoB -> Mux(req_promoteT, toT, toB),
+          BtoT -> toT,
+          NtoT -> toT
         )
       )
     )
@@ -810,8 +809,9 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
     mp_grant.metaWen := !cmo_cbo && !denied
     mp_grant.tagWen := !cmo_cbo && !dirResult.hit && !req_putfull && !denied
     mp_grant.dsWen := (req_putfull || gotGrantData || probeDirty && (req_get || req.aliasTask.getOrElse(false.B))) && !denied
-    mp_grant.putData := req.putData
-    mp_grant.usePutData := req_putfull
+    // TL-to-TL compatibility only; TL-to-CHI Put completion gets payload from RefillBuffer.
+    mp_grant.putData := 0.U.asTypeOf(new DSBlock)
+    mp_grant.usePutData := false.B
     mp_grant.fromL2pft.foreach(_ := req.fromL2pft.get)
     mp_grant.needHint.foreach(_ := false.B)
     mp_grant.replTask := !dirResult.hit && !state.w_replResp && !denied

--- a/src/main/scala/coupledL2/tl2chi/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHR.scala
@@ -464,10 +464,15 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
     mp_release.alias.foreach(_ := 0.U)
     mp_release.vaddr.foreach(_ := 0.U)
     mp_release.isKeyword.foreach(_ := false.B)
-    // if dirty, we must ReleaseData
-    // if accessed, we ReleaseData to keep the data in L3, for future access to be faster
-    // [Access] TODO: consider use a counter
-    mp_release.opcode := 0.U // use chiOpcode
+    // *NOTE*
+    // Q: Why use a constant opcode?
+    // A: We use chiOpcode for MSHR-issued release tasks in the tl2chi branch.
+    // Q: Why use Release instead of 0.U?
+    // A: After we add support for Put, an MSHR release task with opcode 0.U will be treated as an MSHR grant task in MainPipe,
+    //    where it is mistakenly decoded as AccessAck, which is NOT expected.
+    //    This is a tricky workaround. The essential fix is to disable TL opcode decoding where CHI opcode should be used instead, 
+    //    but that would introduce some additional logic.
+    mp_release.opcode := Release
     mp_release.param := Mux(isT(meta.state), TtoN, BtoN)
     mp_release.size := log2Ceil(blockBytes).U
     mp_release.sourceId := 0.U(sourceIdBits.W)
@@ -573,7 +578,7 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
     mp_cbwrdata.alias.foreach(_ := 0.U)
     mp_cbwrdata.vaddr.foreach(_ := 0.U)
     mp_cbwrdata.isKeyword.foreach(_ := false.B)
-    mp_cbwrdata.opcode := 0.U
+    mp_cbwrdata.opcode := Release // Same reason as mp_release.opcode
     mp_cbwrdata.param := 0.U
     mp_cbwrdata.size := log2Ceil(blockBytes).U
     mp_cbwrdata.sourceId := 0.U(sourceIdBits.W)

--- a/src/main/scala/coupledL2/tl2chi/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHR.scala
@@ -390,7 +390,7 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
       req_cboClean                                       -> CleanShared,
       req_cboFlush                                       -> CleanInvalid,
       req_cboInval                                       -> MakeInvalid,
-      req_acquirePerm                                    -> MakeUnique,
+      (req_acquirePerm || req_putfull)                   -> MakeUnique,
       req_needT                                          -> ReadUnique,
       req_needB /* Default */                            -> ReadNotSharedDirty
     ))

--- a/src/main/scala/coupledL2/tl2chi/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHR.scala
@@ -812,7 +812,7 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
       accessed = req_putfull || req_acquire || req_get
     )
     mp_grant.metaWen := !cmo_cbo && !denied
-    mp_grant.tagWen := !cmo_cbo && !dirResult.hit && !req_putfull && !denied
+    mp_grant.tagWen := !cmo_cbo && !dirResult.hit && !denied
     mp_grant.dsWen := (req_putfull || gotGrantData || probeDirty && (req_get || req.aliasTask.getOrElse(false.B))) && !denied
     // TL-to-TL compatibility only; TL-to-CHI Put completion gets payload from RefillBuffer.
     mp_grant.putData := 0.U.asTypeOf(new DSBlock)

--- a/src/main/scala/coupledL2/tl2chi/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHR.scala
@@ -134,9 +134,6 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
     state     := io.alloc.bits.state
     dirResult := io.alloc.bits.dirResult
     req       := io.alloc.bits.task
-    // TL-to-TL compatibility only; TL-to-CHI PutBuffer flow must not store Put payload in TaskBundle.
-    req.putData := 0.U.asTypeOf(new DSBlock)
-    req.usePutData := false.B
     gotT        := false.B
     gotDirty    := false.B
     gotGrantData := false.B
@@ -814,9 +811,6 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
     mp_grant.metaWen := !cmo_cbo && !denied
     mp_grant.tagWen := !cmo_cbo && !dirResult.hit && !denied
     mp_grant.dsWen := (req_putfull || gotGrantData || probeDirty && (req_get || req.aliasTask.getOrElse(false.B))) && !denied
-    // TL-to-TL compatibility only; TL-to-CHI Put completion gets payload from RefillBuffer.
-    mp_grant.putData := 0.U.asTypeOf(new DSBlock)
-    mp_grant.usePutData := false.B
     mp_grant.fromL2pft.foreach(_ := req.fromL2pft.get)
     mp_grant.needHint.foreach(_ := false.B)
     mp_grant.replTask := !dirResult.hit && !state.w_replResp && !denied
@@ -1357,6 +1351,8 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
   io.msInfo.bits.willFree := will_free
   io.msInfo.bits.isAcqOrPrefetch := req_acquire || req_prefetch
   io.msInfo.bits.isPrefetch := req_prefetch
+  // Keep shared MSHRInfo semantics aligned; isPut is currently consumed only by the TL-to-TL RefillUnit.
+  io.msInfo.bits.isPut := req_putfull
   io.msInfo.bits.param := req.param
   io.msInfo.bits.mergeA := mergeA
   io.msInfo.bits.w_grantfirst := state.w_grantfirst

--- a/src/main/scala/coupledL2/tl2chi/MainPipe.scala
+++ b/src/main/scala/coupledL2/tl2chi/MainPipe.scala
@@ -68,9 +68,10 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
     /* read C-channel Release Data and write into DS */
     val bufResp = Input(new PipeBufferResp)
 
-    /* get ReleaseBuffer and RefillBuffer read result */
-    val refillBufResp_s3 = Flipped(ValidIO(new DSBlock))
+    /* get ReleaseBuffer, RefillBuffer, and PutBuffer read result */
+    val refillBufResp_s3  = Flipped(ValidIO(new DSBlock))
     val releaseBufResp_s3 = Flipped(ValidIO(new DSBlock))
+    val putBufResp_s3     = Flipped(ValidIO(new DSBlock))
 
     /* read or write data storage */
     val toDS = new Bundle() {
@@ -95,6 +96,8 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
 
     /* read DS and write data into ReleaseBuf when the task needs to replace */
     val releaseBufWrite = ValidIO(new MSHRBufWrite())
+    /* Store Put data not consumed by DS into RefillBuffer */
+    val refillBufWrite  = ValidIO(new MSHRBufWrite())
 
     /* nested writeback */
     val nestedwb = Output(new NestedWriteback())
@@ -171,7 +174,7 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
   val mshr_grant_s3             = mshr_req_s3 && req_s3.fromA && (req_s3.opcode === Grant || req_s3.opcode === GrantData)
   val mshr_grantdata_s3         = mshr_req_s3 && req_s3.fromA && req_s3.opcode === GrantData
   val mshr_accessackdata_s3     = mshr_req_s3 && req_s3.fromA && req_s3.opcode === AccessAckData
-  val mshr_putack_s3            = mshr_req_s3 && req_s3.fromA && req_s3.opcode === AccessAck && req_s3.usePutData
+  val mshr_putack_s3            = mshr_req_s3 && req_s3.fromA && req_s3.opcode === AccessAck
   val mshr_hintack_s3           = mshr_req_s3 && req_s3.fromA && req_s3.opcode === HintAck
   val mshr_cmoresp_s3           = mshr_req_s3 && req_s3.fromA && req_s3.opcode === CBOAck
 
@@ -232,7 +235,7 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
   /* ======== Interact with MSHR ======== */
   // *NOTICE: A Channel requests should be blocked by RequestBuffer when MSHR nestable,
   //          'nestable_*' must not be used here.
-  val acquire_on_miss_s3 = req_acquire_s3 || req_prefetch_s3 || req_get_s3
+  val acquire_on_miss_s3 = req_acquire_s3 || req_prefetch_s3 || req_get_s3 || req_putfull_s3
   val acquire_on_hit_s3 = meta_s3.state === BRANCH && req_needT_s3 && !req_prefetch_s3
   val need_acquire_s3_a = req_s3.fromA && (Mux(
     dirResult_s3.hit,
@@ -305,7 +308,9 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
     task.mshrTask := false.B
     task.aliasTask.foreach(_ := cache_alias)
     task.wayMask := 0.U(cacheParams.ways.W)
-    // TODO
+    // TL-to-TL compatibility only; TL-to-CHI PutBuffer flow must not carry Put payload in TaskBundle.
+    task.putData := 0.U.asTypeOf(new DSBlock)
+    task.usePutData := false.B
   }
 
   /* ======== Resps to SinkA/B/C Reqs ======== */
@@ -482,16 +487,6 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
   // so it is safe to directly write ReleaseData into DS without MSHR.
   val wen_c = sinkC_req_s3 && isParamFromT(req_s3.param) && req_s3.opcode(0) && dirResult_s3.hit
 
-  // // 
-  // val wen_mshr = req_s3.dsWen && (
-  //   mshr_snpRespX_s3 || mshr_snpRespDataX_s3 ||
-  //   mshr_writeCleanFull_s3 || mshr_writeBackFull_s3 || 
-  //   mshr_writeEvictFull_s3 || mshr_writeEvictOrEvict_s3 || mshr_evict_s3 ||
-  //   mshr_refill_s3 && !need_repl && !retry ||
-  //   mshr_putack_s3
-  // )
-  // val wen_put = req_putfull_s3 && dirResult_s3.hit && isT(meta_s3.state) && !need_mshr_s3_a
-
   // TODO: Can we replace 'isT(meta_s3.state) && !meta_has_clients_s3' with isTip(meta_s3.state)?
   // For Put, only allow write data from PutBuffer into DS when hit with writeable state and no client.
   // Otherwise, we will allocate a MSHR for Put and write data goes to RefillBuffer.
@@ -520,22 +515,24 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
   )
   io.toDS.req_s3.bits.set := Mux(mshr_req_s3, req_s3.set, dirResult_s3.set)
   io.toDS.req_s3.bits.wen := wen
-  io.toDS.wdata_s3.data := Mux(
+  io.toDS.wdata_s3.data   := Mux(
     !mshr_req_s3,
-    Mux(req_putfull_s3, req_s3.putData.data, c_releaseData_s3),
+    Mux(req_putfull_s3, io.putBufResp_s3.bits.data, c_releaseData_s3),
     Mux(
-      req_s3.usePutData,
-      req_s3.putData.data,
-      Mux(
-        req_s3.useProbeData,
-        io.releaseBufResp_s3.bits.data,
-        io.refillBufResp_s3.bits.data
-      )
+      req_s3.useProbeData,
+      io.releaseBufResp_s3.bits.data,
+      io.refillBufResp_s3.bits.data
     )
   )
 
-  assert(!(task_s3.valid && req_putfull_s3 && (!dirResult_s3.hit || !isT(meta_s3.state))),
-    "Matrix PutFullData only supports hit with write-capable state; TODO: support miss/permission-acquire path")
+  /* ======== Route Put data not consumed by DS to the RefillBuffer ======== */
+  // A valid task that read PutBuffer in s2 must consume that payload in s3: direct DS write or RefillBuffer handoff.
+  // As a result, if the put data is NOT consumed by DS (!wen_src_putBuf),
+  // then it must be written into RefillBuffer for later use.
+  io.refillBufWrite.valid         := task_s3.valid && steer_s2.putBufRead && !wen_src_putBuf
+  io.refillBufWrite.bits.id       := io.fromMSHRCtl.mshr_alloc_ptr
+  io.refillBufWrite.bits.data     := io.putBufResp_s3.bits
+  io.refillBufWrite.bits.beatMask := Fill(beatSize, true.B)
 
   /* ======== Read DS and store data in Buffer ======== */
   // A: need_write_releaseBuf indicates that DS should be read and the data will be written into ReleaseBuffer

--- a/src/main/scala/coupledL2/tl2chi/MainPipe.scala
+++ b/src/main/scala/coupledL2/tl2chi/MainPipe.scala
@@ -137,7 +137,8 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
   val d_s3, d_s4, d_s5 = Wire(io.toSourceD.cloneType)
 
   /* ======== Stage 2 ======== */
-  val task_s2 = io.taskFromArb_s2
+  val task_s2  = io.taskFromArb_s2
+  val steer_s2 = io.fromReqArb.steer_s2
 
   /* ======== Stage 3 ======== */
   val task_s3 = RegInit(0.U.asTypeOf(Valid(new TaskBundle)))
@@ -476,16 +477,29 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
   val need_data_cmo = cmo_cbo_s3 && nestable_dirResult_s3.hit && nestable_meta_s3.dirty
   val ren = need_data_a || need_data_b || need_data_mshr_repl || need_data_cmo
 
+  // Write ReleaseData from upstream c-channel into DS.
+  // Because of the inclusive property of the cache, when Release comes, the cache line must be in the cache and the directory must hit, 
+  // so it is safe to directly write ReleaseData into DS without MSHR.
   val wen_c = sinkC_req_s3 && isParamFromT(req_s3.param) && req_s3.opcode(0) && dirResult_s3.hit
-  val wen_mshr = req_s3.dsWen && (
-    mshr_snpRespX_s3 || mshr_snpRespDataX_s3 ||
-    mshr_writeCleanFull_s3 || mshr_writeBackFull_s3 || 
-    mshr_writeEvictFull_s3 || mshr_writeEvictOrEvict_s3 || mshr_evict_s3 ||
-    mshr_refill_s3 && !need_repl && !retry ||
-    mshr_putack_s3
-  )
-  val wen_put = req_putfull_s3 && dirResult_s3.hit && isT(meta_s3.state) && !need_mshr_s3_a
-  val wen = wen_c || wen_put || wen_mshr
+
+  // // 
+  // val wen_mshr = req_s3.dsWen && (
+  //   mshr_snpRespX_s3 || mshr_snpRespDataX_s3 ||
+  //   mshr_writeCleanFull_s3 || mshr_writeBackFull_s3 || 
+  //   mshr_writeEvictFull_s3 || mshr_writeEvictOrEvict_s3 || mshr_evict_s3 ||
+  //   mshr_refill_s3 && !need_repl && !retry ||
+  //   mshr_putack_s3
+  // )
+  // val wen_put = req_putfull_s3 && dirResult_s3.hit && isT(meta_s3.state) && !need_mshr_s3_a
+
+  // TODO: Can we replace 'isT(meta_s3.state) && !meta_has_clients_s3' with isTip(meta_s3.state)?
+  // For Put, only allow write data from PutBuffer into DS when hit with writeable state and no client.
+  // Otherwise, we will allocate a MSHR for Put and write data goes to RefillBuffer.
+  val wen_src_putBuf = steer_s2.putBufRead && dirResult_s3.hit && isT(meta_s3.state) && !meta_has_clients_s3
+
+  val wen_src_refillBuf  = steer_s2.refillBufRead  && req_s3.dsWen && !need_repl && !retry
+  val wen_src_releaseBuf = steer_s2.releaseBufRead && req_s3.dsWen
+  val wen = wen_c || wen_src_putBuf || wen_src_refillBuf || wen_src_releaseBuf
 
   // This is to let io.toDS.req_s3.valid hold for 2 cycles (see DataStorage for details)
   val task_s3_valid_hold2 = RegInit(0.U(2.W))

--- a/src/main/scala/coupledL2/tl2chi/MainPipe.scala
+++ b/src/main/scala/coupledL2/tl2chi/MainPipe.scala
@@ -69,9 +69,9 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
     val bufResp = Input(new PipeBufferResp)
 
     /* get ReleaseBuffer, RefillBuffer, and PutBuffer read result */
-    val refillBufResp_s3  = Flipped(ValidIO(new DSBlock))
-    val releaseBufResp_s3 = Flipped(ValidIO(new DSBlock))
-    val putBufResp_s3     = Flipped(ValidIO(new DSBlock))
+    val refillBufResp_s3  = Input(new DSBlock)
+    val releaseBufResp_s3 = Input(new DSBlock)
+    val putBufResp_s3     = Input(new DSBlock)
 
     /* read or write data storage */
     val toDS = new Bundle() {
@@ -470,7 +470,7 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
   source_req_s3.isKeyword.foreach(_ := req_s3.isKeyword.getOrElse(false.B))
 
   /* ======== Interact with DS ======== */
-  val data_s3 = Mux(io.releaseBufResp_s3.valid, io.releaseBufResp_s3.bits.data, io.refillBufResp_s3.bits.data)
+  val data_s3 = Mux(steer_s2.releaseBufRead, io.releaseBufResp_s3.data, io.refillBufResp_s3.data)
   val c_releaseData_s3 = io.bufResp.data.asUInt
   val hasData_s3_tl = source_req_s3.opcode(0) // whether to respond data to TileLink-side
   val hasData_s3_chi = source_req_s3.toTXDAT // whether to respond data to CHI-side
@@ -517,11 +517,11 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
   io.toDS.req_s3.bits.wen := ds_wen
   io.toDS.wdata_s3.data   := Mux(
     !mshr_req_s3,
-    Mux(req_putfull_s3, io.putBufResp_s3.bits.data, c_releaseData_s3),
+    Mux(req_putfull_s3, io.putBufResp_s3.data, c_releaseData_s3),
     Mux(
       req_s3.useProbeData,
-      io.releaseBufResp_s3.bits.data,
-      io.refillBufResp_s3.bits.data
+      io.releaseBufResp_s3.data,
+      io.refillBufResp_s3.data
     )
   )
 
@@ -531,7 +531,7 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
   // then it must be written into RefillBuffer for later use.
   io.refillBufWrite.valid         := task_s3.valid && steer_s2.putBufRead && !wen_src_putBuf
   io.refillBufWrite.bits.id       := io.fromMSHRCtl.mshr_alloc_ptr
-  io.refillBufWrite.bits.data     := io.putBufResp_s3.bits
+  io.refillBufWrite.bits.data     := io.putBufResp_s3
   io.refillBufWrite.bits.beatMask := Fill(beatSize, true.B)
 
   /* ======== Read DS and store data in Buffer ======== */

--- a/src/main/scala/coupledL2/tl2chi/MainPipe.scala
+++ b/src/main/scala/coupledL2/tl2chi/MainPipe.scala
@@ -624,7 +624,7 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
     MetaEntry()
   )
 
-  io.tagWReq.valid := task_s3.valid && req_s3.tagWen && mshr_refill_s3 && !retry
+  io.tagWReq.valid := task_s3.valid && req_s3.tagWen && !retry
   io.tagWReq.bits.set := req_s3.set
   io.tagWReq.bits.way := Mux(mshr_refill_s3 && req_s3.replTask, io.replResp.bits.way, req_s3.way)
   io.tagWReq.bits.wtag := req_s3.tag

--- a/src/main/scala/coupledL2/tl2chi/MainPipe.scala
+++ b/src/main/scala/coupledL2/tl2chi/MainPipe.scala
@@ -39,6 +39,7 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
     /* handle set conflict in req arb */
     val fromReqArb = Input(new Bundle() {
       val status_s1 = new PipeEntranceStatus
+      val steer_s2  = new SteerS2ToS3
     })
     /* block B and C at Entrance */
     val toReqArb = Output(new BlockInfo())

--- a/src/main/scala/coupledL2/tl2chi/MainPipe.scala
+++ b/src/main/scala/coupledL2/tl2chi/MainPipe.scala
@@ -308,9 +308,6 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
     task.mshrTask := false.B
     task.aliasTask.foreach(_ := cache_alias)
     task.wayMask := 0.U(cacheParams.ways.W)
-    // TL-to-TL compatibility only; TL-to-CHI PutBuffer flow must not carry Put payload in TaskBundle.
-    task.putData := 0.U.asTypeOf(new DSBlock)
-    task.usePutData := false.B
   }
 
   /* ======== Resps to SinkA/B/C Reqs ======== */

--- a/src/main/scala/coupledL2/tl2chi/MainPipe.scala
+++ b/src/main/scala/coupledL2/tl2chi/MainPipe.scala
@@ -225,7 +225,7 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
   val dataError_s3              = meta_s3.dataErr
   val l2Error_s3                = io.dirResp_s3.error
 
-  val mshr_refill_s3 = mshr_accessackdata_s3 || mshr_hintack_s3 || mshr_grant_s3 // needs refill to L2 DS
+  val mshr_refill_s3 = mshr_accessackdata_s3 || mshr_putack_s3 || mshr_hintack_s3 || mshr_grant_s3 // needs refill to L2 DS
   val replResp_valid_s3 = io.replResp.valid
   val replResp_valid_s4 = RegNext(io.replResp.valid, init = false.B)
   val replResp_valid_hold = replResp_valid_s3 || replResp_valid_s4

--- a/src/main/scala/coupledL2/tl2chi/MainPipe.scala
+++ b/src/main/scala/coupledL2/tl2chi/MainPipe.scala
@@ -496,15 +496,15 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
   val wen_src_releaseBuf = steer_s2.releaseBufRead && req_s3.dsWen
   val wen = wen_c || wen_src_putBuf || wen_src_refillBuf || wen_src_releaseBuf
 
-  // This is to let io.toDS.req_s3.valid hold for 2 cycles (see DataStorage for details)
-  val task_s3_valid_hold2 = RegInit(0.U(2.W))
-  when(task_s2.valid) {
-    task_s3_valid_hold2 := "b11".U
-  }.otherwise {
-    task_s3_valid_hold2 := task_s3_valid_hold2 >> 1.U
-  }
   val ds_en = task_s3.valid && (ren || wen)
-  val ds_valid = if (enableMCP2) task_s3_valid_hold2(0) && (ren || wen) else task_s3.valid && (ren || wen)
+  val ds_wen_s3 = task_s3.valid && wen
+
+  // Under MCP2, DataStorage requires io.toDS.req_s3.valid and its payloads to remain stable for an extra cycle after ds_en is asserted.
+  // Since normal S3 steering is deasserted once the task leaves S3, valid and wen must be explicitly held for the MCP2 hold cycle.
+  val ds_valid = if (enableMCP2) ds_en || RegNext(ds_en) else ds_en
+  // TODO: task_s3.valid can be removed if UpReleaseBuffer is impl and wen_c is replaced with steer.
+  //       Because steers imply that the task is valid.
+  val ds_wen   = if (enableMCP2) ds_wen_s3 || RegNext(ds_wen_s3) else ds_wen_s3
 
   io.toDS.en_s3 := ds_en
   io.toDS.req_s3.valid := ds_valid
@@ -514,7 +514,7 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
     Mux(mshr_req_s3, req_s3.way, dirResult_s3.way)
   )
   io.toDS.req_s3.bits.set := Mux(mshr_req_s3, req_s3.set, dirResult_s3.set)
-  io.toDS.req_s3.bits.wen := wen
+  io.toDS.req_s3.bits.wen := ds_wen
   io.toDS.wdata_s3.data   := Mux(
     !mshr_req_s3,
     Mux(req_putfull_s3, io.putBufResp_s3.bits.data, c_releaseData_s3),

--- a/src/main/scala/coupledL2/tl2chi/Slice.scala
+++ b/src/main/scala/coupledL2/tl2chi/Slice.scala
@@ -114,6 +114,7 @@ class Slice()(implicit p: Parameters) extends BaseSlice[OuterBundle]
   mainPipe.io.taskFromArb_s2 := reqArb.io.taskToPipe_s2
   mainPipe.io.taskInfo_s1 := reqArb.io.taskInfo_s1
   mainPipe.io.fromReqArb.status_s1 := reqArb.io.status_s1
+  mainPipe.io.fromReqArb.steer_s2  := reqArb.io.steerToPipe_s2
   mainPipe.io.bufResp := sinkC.io.bufResp
   mainPipe.io.dirResp_s3 := directory.io.resp.bits
   mainPipe.io.replResp := directory.io.replResp

--- a/src/main/scala/coupledL2/tl2chi/Slice.scala
+++ b/src/main/scala/coupledL2/tl2chi/Slice.scala
@@ -52,7 +52,8 @@ class Slice()(implicit p: Parameters) extends BaseSlice[OuterBundle]
   /* Data path and control path */
   val directory = Module(new Directory())
   val dataStorage = Module(new DataStorage())
-  val refillBuf = Module(new MSHRBuffer(wPorts = 2))
+  val putBuf = Module(new PutBuffer)
+  val refillBuf = Module(new MSHRBuffer(wPorts = 3))
   val releaseBuf = Module(new MSHRBuffer(wPorts = 3))
 
   val reqArb = Module(new RequestArb())
@@ -124,6 +125,8 @@ class Slice()(implicit p: Parameters) extends BaseSlice[OuterBundle]
   mainPipe.io.refillBufResp_s3.bits := refillBuf.io.resp.data
   mainPipe.io.releaseBufResp_s3.valid := RegNext(releaseBuf.io.r.valid, false.B)
   mainPipe.io.releaseBufResp_s3.bits := releaseBuf.io.resp.data
+  mainPipe.io.putBufResp_s3.valid := RegNext(putBuf.io.r.valid, false.B)
+  mainPipe.io.putBufResp_s3.bits := putBuf.io.resp.data
   mainPipe.io.toDS.rdata_s5 := dataStorage.io.rdata
   mainPipe.io.toDS.error_s5 := dataStorage.io.error
   // mainPipe.io.grantBufferHint := grantBuf.io.l1Hint
@@ -165,7 +168,16 @@ class Slice()(implicit p: Parameters) extends BaseSlice[OuterBundle]
 
   /* Read and write refill buffer */
   refillBuf.io.r := reqArb.io.refillBufRead_s2
-  refillBuf.io.w <> VecInit(Seq(rxdat.io.refillBufWrite, sinkC.io.refillBufWrite))
+  refillBuf.io.w <> VecInit(Seq(
+    rxdat.io.refillBufWrite,
+    sinkC.io.refillBufWrite,
+    mainPipe.io.refillBufWrite
+  ))
+
+  /* Read and write put buffer */
+  sinkA.io.pBufState := putBuf.io.state
+  putBuf.io.w        <> sinkA.io.putBufWrite
+  putBuf.io.r        := reqArb.io.putBufRead_s2
 
   io.prefetch.foreach { p =>
     p.train <> mainPipe.io.prefetchTrain.get

--- a/src/main/scala/coupledL2/tl2chi/Slice.scala
+++ b/src/main/scala/coupledL2/tl2chi/Slice.scala
@@ -121,12 +121,9 @@ class Slice()(implicit p: Parameters) extends BaseSlice[OuterBundle]
   mainPipe.io.replResp := directory.io.replResp
   mainPipe.io.fromMSHRCtl <> mshrCtl.io.toMainPipe
   mainPipe.io.bufResp := sinkC.io.bufResp
-  mainPipe.io.refillBufResp_s3.valid := RegNext(refillBuf.io.r.valid, false.B)
-  mainPipe.io.refillBufResp_s3.bits := refillBuf.io.resp.data
-  mainPipe.io.releaseBufResp_s3.valid := RegNext(releaseBuf.io.r.valid, false.B)
-  mainPipe.io.releaseBufResp_s3.bits := releaseBuf.io.resp.data
-  mainPipe.io.putBufResp_s3.valid := RegNext(putBuf.io.r.valid, false.B)
-  mainPipe.io.putBufResp_s3.bits := putBuf.io.resp.data
+  mainPipe.io.refillBufResp_s3 := refillBuf.io.resp.data
+  mainPipe.io.releaseBufResp_s3 := releaseBuf.io.resp.data
+  mainPipe.io.putBufResp_s3 := putBuf.io.resp.data
   mainPipe.io.toDS.rdata_s5 := dataStorage.io.rdata
   mainPipe.io.toDS.error_s5 := dataStorage.io.error
   // mainPipe.io.grantBufferHint := grantBuf.io.l1Hint

--- a/src/main/scala/coupledL2/tl2tl/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2tl/MSHR.scala
@@ -131,7 +131,9 @@ class MSHR(implicit p: Parameters) extends L2Module {
     oa.set := req.set
     oa.off := req.off
     oa.source := io.id
-    // TODO: evaluate whether TL true-miss PutFullData can later use a permission-only path.
+    // TL-to-TL Put hit uses AcquirePerm to request write permission.
+    // Due to a downstream L3 limitation, a true-miss Put must still use AcquireBlock and receive GrantData.
+    // RefillUnit accepts the response normally but suppresses its RefillBuffer write for a Put MSHR.
     oa.opcode := Mux(
       req_putfull,
       Mux(dirResult.hit, AcquirePerm, AcquireBlock),
@@ -204,11 +206,9 @@ class MSHR(implicit p: Parameters) extends L2Module {
     mp_release.mshrTask := true.B
     mp_release.mshrId := io.id
     mp_release.aliasTask.foreach(_ := false.B)
-    // mp_release reads releaseBuf for outgoing ReleaseData when needed.
-    // Its final DS write comes either from refillBuf (normal refill install) or req.putData (PutFullData install).
+    // mp_release reads ReleaseBuffer for outgoing ReleaseData when needed.
+    // Its replacement-safe DS write always reads the final payload from RefillBuffer.
     mp_release.useProbeData := false.B
-    mp_release.putData := req.putData
-    mp_release.usePutData := req_putfull
     mp_release.readProbeDataDown := mp_release.opcode === ReleaseData
     mp_release.mshrRetry := false.B
     mp_release.way := dirResult.way
@@ -218,7 +218,7 @@ class MSHR(implicit p: Parameters) extends L2Module {
     mp_release.metaWen := false.B
     mp_release.meta := MetaEntry()
     mp_release.tagWen := false.B
-    mp_release.dsWen := true.B // write refillData or PutData to DS at the replacement-safe point
+    mp_release.dsWen := true.B // write RefillBuffer data to DS at the replacement-safe point
     mp_release.replTask := true.B
     mp_release.wayMask := 0.U(cacheParams.ways.W)
     mp_release.reqSource := 0.U(MemReqSource.reqSourceBits.W)
@@ -386,8 +386,6 @@ class MSHR(implicit p: Parameters) extends L2Module {
     mp_grant.metaWen := true.B
     mp_grant.tagWen := !dirResult.hit
     mp_grant.dsWen := req_putfull || gotGrantData || probeDirty && (req_get || req.aliasTask.getOrElse(false.B))
-    mp_grant.putData := req.putData
-    mp_grant.usePutData := req_putfull
     mp_grant.fromL2pft.foreach(_ := req.fromL2pft.get)
     mp_grant.needHint.foreach(_ := false.B)
     mp_grant.replTask := !dirResult.hit // Get and Alias are hit that does not need replacement
@@ -594,6 +592,7 @@ class MSHR(implicit p: Parameters) extends L2Module {
   io.msInfo.bits.willFree := will_free
   io.msInfo.bits.isAcqOrPrefetch := req_acquire || req_prefetch
   io.msInfo.bits.isPrefetch := req_prefetch
+  io.msInfo.bits.isPut := req_putfull
   io.msInfo.bits.param := req.param
   io.msInfo.bits.mergeA := mergeA
   io.msInfo.bits.w_grantfirst := state.w_grantfirst

--- a/src/main/scala/coupledL2/tl2tl/MainPipe.scala
+++ b/src/main/scala/coupledL2/tl2tl/MainPipe.scala
@@ -38,6 +38,7 @@ class MainPipe(implicit p: Parameters) extends L2Module with HasPerfEvents {
     /* handle set conflict in req arb */
     val fromReqArb = Input(new Bundle() {
       val status_s1 = new PipeEntranceStatus
+      val steer_s2 = new SteerS2ToS3
     })
     /* block B and C at Entrance */
     val toReqArb = Output(new BlockInfo())
@@ -67,8 +68,9 @@ class MainPipe(implicit p: Parameters) extends L2Module with HasPerfEvents {
     val bufResp = Input(new PipeBufferResp)
 
     /* get ReleaseBuffer and RefillBuffer read result */
-    val refillBufResp_s3 = Flipped(ValidIO(new DSBlock))
-    val releaseBufResp_s3 = Flipped(ValidIO(new DSBlock))
+    val refillBufResp_s3 = Input(new DSBlock)
+    val releaseBufResp_s3 = Input(new DSBlock)
+    val putBufResp_s3 = Input(new DSBlock)
 
     /* read or write data storage */
     val toDS = new Bundle() {
@@ -91,6 +93,9 @@ class MainPipe(implicit p: Parameters) extends L2Module with HasPerfEvents {
 
     /* read DS and write data into ReleaseBuf when the task needs to replace */
     val releaseBufWrite = ValidIO(new MSHRBufWrite())
+
+    /* Store Put data not consumed by DS into RefillBuffer */
+    val refillBufWrite = ValidIO(new MSHRBufWrite())
 
     val nestedwb = Output(new NestedWriteback)
     val nestedwbData = Output(new DSBlock)
@@ -125,6 +130,7 @@ class MainPipe(implicit p: Parameters) extends L2Module with HasPerfEvents {
   /* ======== Stage 2 ======== */
   // send out MSHR task if data is not needed
   val task_s2 = io.taskFromArb_s2
+  val steer_s2 = io.fromReqArb.steer_s2
   val hasData_s2 = task_s2.bits.opcode(0)
 
   /* ======== Stage 3 ======== */
@@ -158,9 +164,7 @@ class MainPipe(implicit p: Parameters) extends L2Module with HasPerfEvents {
   val mshr_grant_s3         = mshr_req_s3 && req_s3.fromA && (req_s3.opcode === Grant || req_s3.opcode === GrantData) // Grant or GrantData from mshr
   val mshr_grantdata_s3     = mshr_req_s3 && req_s3.fromA && req_s3.opcode === GrantData
   val mshr_accessackdata_s3 = mshr_req_s3 && req_s3.fromA && req_s3.opcode === AccessAckData
-  val mshr_putack_s3        = mshr_req_s3 && req_s3.fromA && req_s3.opcode === AccessAck && req_s3.usePutData
-  val mshr_put_install_s3   = mshr_putack_s3 && req_s3.replTask
-  val mshr_put_fast_s3      = mshr_putack_s3 && !req_s3.replTask
+  val mshr_putack_s3        = mshr_req_s3 && req_s3.fromA && req_s3.opcode === AccessAck
   val mshr_hintack_s3       = mshr_req_s3 && req_s3.fromA && req_s3.opcode === HintAck
   val mshr_probeack_s3      = mshr_req_s3 && req_s3.fromB && (req_s3.opcode === ProbeAck || req_s3.opcode === ProbeAckData) // ProbeAck or ProbeAckData from mshr
   val mshr_probeackdata_s3  = mshr_req_s3 && req_s3.fromB && req_s3.opcode === ProbeAckData
@@ -175,8 +179,7 @@ class MainPipe(implicit p: Parameters) extends L2Module with HasPerfEvents {
   val cache_alias           = req_acquire_s3 && dirResult_s3.hit && meta_s3.clients(0) &&
                               meta_s3.alias.getOrElse(0.U) =/= req_s3.alias.getOrElse(0.U)
 
-  val mshr_refill_s3 = (mshr_accessackdata_s3 || mshr_hintack_s3 || mshr_grant_s3) // needs refill to L2 DS
-  val mshr_install_s3 = mshr_refill_s3 || mshr_put_install_s3
+  val mshr_refill_s3 = mshr_accessackdata_s3 || mshr_putack_s3 || mshr_hintack_s3 || mshr_grant_s3
   val retry = io.replResp.bits.retry
   val need_repl = io.replResp.bits.meta.state =/= INVALID && req_s3.replTask // Grant needs replacement
 
@@ -233,8 +236,6 @@ class MainPipe(implicit p: Parameters) extends L2Module with HasPerfEvents {
   ms_task.fromL2pft.foreach(_ := req_s3.fromL2pft.get)
   ms_task.needHint.foreach(_  := req_s3.needHint.get)
   ms_task.dirty            := false.B
-  ms_task.putData          := req_s3.putData
-  ms_task.usePutData       := req_s3.usePutData
   ms_task.way              := req_s3.way
   ms_task.meta             := 0.U.asTypeOf(new MetaEntry)
   ms_task.metaWen          := false.B
@@ -297,57 +298,59 @@ class MainPipe(implicit p: Parameters) extends L2Module with HasPerfEvents {
   source_req_s3 := Mux(sink_resp_s3.valid, sink_resp_s3.bits, req_s3)
   source_req_s3.isKeyword.foreach(_ := req_s3.isKeyword.getOrElse(false.B))
   /* ======== Interact with DS ======== */
-  val data_s3 = Mux(io.releaseBufResp_s3.valid, io.releaseBufResp_s3.bits.data, io.refillBufResp_s3.bits.data) // releaseBuf prior
+  val data_s3 = Mux(steer_s2.releaseBufRead, io.releaseBufResp_s3.data, io.refillBufResp_s3.data)
   val c_releaseData_s3 = io.bufResp.data.asUInt
   val hasData_s3 = source_req_s3.opcode(0)
 
   val need_data_a  = dirResult_s3.hit && (req_get_s3 || req_acquireBlock_s3)
   val need_data_b  = sinkB_req_s3 && dirResult_s3.hit &&
                        (meta_s3.state === TRUNK || meta_s3.state === TIP && meta_s3.dirty || req_s3.needProbeAckData)
-  val need_data_mshr_repl = mshr_install_s3 && need_repl && !retry
+  val need_data_mshr_repl = mshr_refill_s3 && need_repl && !retry
   val ren                 = need_data_a || need_data_b || need_data_mshr_repl
 
   val wen_c = sinkC_req_s3 && isParamFromT(req_s3.param) && req_s3.opcode(0) && dirResult_s3.hit
-  val wen_put = req_putfull_s3 && dirResult_s3.hit && isT(meta_s3.state) && !need_mshr_s3_a
-  val wen_mshr = req_s3.dsWen && (
-    mshr_probeack_s3 || mshr_release_s3 ||
-    mshr_refill_s3 && !need_repl && !retry ||
-    mshr_put_fast_s3 || mshr_put_install_s3 && !need_repl && !retry
-  )
-  val wen   = wen_c || wen_put || wen_mshr
+  // TODO: Can we replace 'isT(meta_s3.state) && !meta_has_clients_s3' with isTip(meta_s3.state)?
+  // For Put, only allow write data from PutBuffer into DS when hit with writeable state and no client.
+  // Otherwise, we will allocate a MSHR for Put and write data goes to RefillBuffer.
+  val wen_src_putBuf =
+    steer_s2.putBufRead && dirResult_s3.hit && isT(meta_s3.state) && !meta_has_clients_s3
+  val wen_src_refillBuf = steer_s2.refillBufRead && req_s3.dsWen && !need_repl && !retry
+  val wen_src_releaseBuf = steer_s2.releaseBufRead && req_s3.dsWen
+  val wen = wen_c || wen_src_putBuf || wen_src_refillBuf || wen_src_releaseBuf
 
-  // This is to let io.toDS.req_s3.valid hold for 2 cycles (see DataStorage for details)
-  val task_s3_valid_hold2 = RegInit(0.U(2.W))
-  when(task_s2.valid) {
-    task_s3_valid_hold2 := "b11".U
-  }.otherwise {
-    task_s3_valid_hold2 := task_s3_valid_hold2 >> 1.U
-  }
-  val ds_en    = task_s3.valid && (ren || wen)
-  val ds_valid = if(enableMCP2) task_s3_valid_hold2(0) && (ren || wen) else task_s3.valid && (ren || wen)
+  val ds_en = task_s3.valid && (ren || wen)
+  val ds_wen_s3 = task_s3.valid && wen
+
+  // Under MCP2, DataStorage requires io.toDS.req_s3.valid and its payloads to remain stable for an extra cycle
+  // after ds_en is asserted. Since normal S3 steering is deasserted once the task leaves S3, valid and wen must
+  // be explicitly held for the MCP2 hold cycle.
+  val ds_valid = if (enableMCP2) ds_en || RegNext(ds_en) else ds_en
+  val ds_wen = if (enableMCP2) ds_wen_s3 || RegNext(ds_wen_s3) else ds_wen_s3
 
   io.toDS.en_s3           := ds_en
   io.toDS.req_s3.valid    := ds_valid
-  io.toDS.req_s3.bits.way := Mux(mshr_install_s3 && req_s3.replTask, io.replResp.bits.way,
+  io.toDS.req_s3.bits.way := Mux(mshr_refill_s3 && req_s3.replTask, io.replResp.bits.way,
     Mux(mshr_req_s3, req_s3.way, dirResult_s3.way))
   io.toDS.req_s3.bits.set := Mux(mshr_req_s3, req_s3.set, dirResult_s3.set)
-  io.toDS.req_s3.bits.wen := wen
+  io.toDS.req_s3.bits.wen := ds_wen
   io.toDS.wdata_s3.data := Mux(
     !mshr_req_s3,
-    Mux(req_putfull_s3, req_s3.putData.data, c_releaseData_s3),
+    Mux(req_putfull_s3, io.putBufResp_s3.data, c_releaseData_s3),
     Mux(
-      req_s3.usePutData,
-      req_s3.putData.data,
-      Mux(
-        req_s3.useProbeData,
-        io.releaseBufResp_s3.bits.data,
-        io.refillBufResp_s3.bits.data
-      )
+      req_s3.useProbeData,
+      io.releaseBufResp_s3.data,
+      io.refillBufResp_s3.data
     )
   )
 
-  assert(!(task_s3.valid && req_putfull_s3 && !need_mshr_s3_a && (!dirResult_s3.hit || !isT(meta_s3.state))),
-    "Matrix PutFullData direct MainPipe path requires hit with write-capable state")
+  /* ======== Route Put data not consumed by DS to the RefillBuffer ======== */
+  // A valid task that read PutBuffer in s2 must consume that payload in s3: direct DS write or RefillBuffer handoff.
+  // As a result, if the put data is NOT consumed by DS (!wen_src_putBuf),
+  // then it must be written into RefillBuffer for later use.
+  io.refillBufWrite.valid := task_s3.valid && steer_s2.putBufRead && !wen_src_putBuf
+  io.refillBufWrite.bits.id := io.fromMSHRCtl.mshr_alloc_ptr
+  io.refillBufWrite.bits.data := io.putBufResp_s3
+  io.refillBufWrite.bits.beatMask := Fill(beatSize, true.B)
 
   /* ======== Read DS and store data in Buffer ======== */
   // A: need_write_releaseBuf indicates that DS should be read and the data will be written into ReleaseBuffer
@@ -366,7 +369,7 @@ class MainPipe(implicit p: Parameters) extends L2Module with HasPerfEvents {
   val metaW_valid_s3_a    = sinkA_req_s3 && !need_mshr_s3_a && !req_get_s3 && !req_prefetch_s3 // get & prefetch that hit will not write meta
   val metaW_valid_s3_b    = sinkB_req_s3 && !need_mshr_s3_b && dirResult_s3.hit && (meta_s3.state === TIP || meta_s3.state === BRANCH && req_s3.param === toN)
   val metaW_valid_s3_c    = sinkC_req_s3 && dirResult_s3.hit
-  val metaW_valid_s3_mshr = mshr_req_s3 && req_s3.metaWen && !(mshr_install_s3 && retry)
+  val metaW_valid_s3_mshr = mshr_req_s3 && req_s3.metaWen && !(mshr_refill_s3 && retry)
   require(clientBits == 1)
 
   // Get and Prefetch should not change alias bit
@@ -409,7 +412,7 @@ class MainPipe(implicit p: Parameters) extends L2Module with HasPerfEvents {
   metaW_s3_mshr.tagErr := req_s3.denied
   metaW_s3_mshr.dataErr := req_s3.corrupt
 
-  val metaW_way = Mux(mshr_install_s3 && req_s3.replTask, io.replResp.bits.way, // install-coordinated A replies use replResp way
+  val metaW_way = Mux(mshr_refill_s3 && req_s3.replTask, io.replResp.bits.way, // install-coordinated A replies use replResp way
     Mux(mshr_req_s3, req_s3.way, dirResult_s3.way))
 
   io.metaWReq.valid      := !resetFinish || task_s3.valid && (metaW_valid_s3_a || metaW_valid_s3_b || metaW_valid_s3_c || metaW_valid_s3_mshr)
@@ -424,9 +427,9 @@ class MainPipe(implicit p: Parameters) extends L2Module with HasPerfEvents {
     MetaEntry()
   )
 
-  io.tagWReq.valid     := task_s3.valid && req_s3.tagWen && mshr_install_s3 && !retry
+  io.tagWReq.valid     := task_s3.valid && req_s3.tagWen && !retry
   io.tagWReq.bits.set  := req_s3.set
-  io.tagWReq.bits.way  := Mux(mshr_install_s3 && req_s3.replTask, io.replResp.bits.way, req_s3.way)
+  io.tagWReq.bits.way  := Mux(mshr_refill_s3 && req_s3.replTask, io.replResp.bits.way, req_s3.way)
   io.tagWReq.bits.wtag := req_s3.tag
 
   /* ======== Interact with Channels (C & D) ======== */
@@ -434,7 +437,7 @@ class MainPipe(implicit p: Parameters) extends L2Module with HasPerfEvents {
   val chnl_fire_s3 = c_s3.fire || d_s3.fire
   val req_drop_s3 = !need_write_releaseBuf && (
     !mshr_req_s3 && need_mshr_s3 || chnl_fire_s3
-  ) || (mshr_install_s3 && retry)
+  ) || (mshr_refill_s3 && retry)
 
   val data_unready_s3 = hasData_s3 && !mshr_req_s3
   val isC_s3 = Mux(
@@ -444,7 +447,7 @@ class MainPipe(implicit p: Parameters) extends L2Module with HasPerfEvents {
   )
   val isD_s3 = Mux(
     mshr_req_s3,
-    (mshr_install_s3 && !retry) || mshr_put_fast_s3,
+    mshr_refill_s3 && !retry || mshr_putack_s3,
     req_s3.fromC || req_s3.fromA && !need_mshr_s3 && !data_unready_s3 && req_s3.opcode =/= Hint
   ) // prefetch-hit will not generate response
   c_s3.valid := task_s3.valid && isC_s3
@@ -634,7 +637,7 @@ class MainPipe(implicit p: Parameters) extends L2Module with HasPerfEvents {
   require(io.status_vec_toD.size == 3)
   io.status_vec_toD(0).valid := task_s3.valid && Mux(
     mshr_req_s3,
-    (mshr_install_s3 && !retry) || mshr_put_fast_s3,
+    mshr_refill_s3 && !retry || mshr_putack_s3,
     true.B
     // TODO:
     // To consider grantBuffer capacity conflict, only " req_s3.fromC || req_s3.fromA && !need_mshr_s3 " is needed

--- a/src/main/scala/coupledL2/tl2tl/RefillUnit.scala
+++ b/src/main/scala/coupledL2/tl2tl/RefillUnit.scala
@@ -40,6 +40,7 @@ class RefillUnit(implicit p: Parameters) extends L2Module {
     val sourceE = DecoupledIO(new TLBundleE(edgeOut.bundle))
     val refillBufWrite = ValidIO(new MSHRBufWrite)
     val resp = Output(new RespBundle)
+    val msInfo = Vec(mshrsAll, Flipped(ValidIO(new MSHRInfo)))
   })
 
   val (first, last, _, beat) = edgeOut.count(io.sinkD)
@@ -58,7 +59,10 @@ class RefillUnit(implicit p: Parameters) extends L2Module {
 
   val grantDataBuf = RegEnable(io.sinkD.bits.data, 0.U((beatBytes * 8).W), io.sinkD.valid && hasData && first)
 
-  io.refillBufWrite.valid := io.sinkD.valid && hasData && last
+  val msSel = io.msInfo(io.sinkD.bits.source)
+  val putRefill = msSel.valid && msSel.bits.isPut
+
+  io.refillBufWrite.valid := io.sinkD.valid && hasData && last && !putRefill
   io.refillBufWrite.bits.id := io.sinkD.bits.source
   io.refillBufWrite.bits.data.data := Cat(io.sinkD.bits.data, grantDataBuf)
   io.refillBufWrite.bits.beatMask := Fill(beatSize, true.B)

--- a/src/main/scala/coupledL2/tl2tl/Slice.scala
+++ b/src/main/scala/coupledL2/tl2tl/Slice.scala
@@ -48,7 +48,8 @@ class Slice()(implicit p: Parameters) extends BaseSlice[OuterBundle] {
   val sinkC = Module(new SinkC)
   val sourceC = Module(new SourceC)
   val grantBuf = Module(new GrantBuffer)
-  val refillBuf = Module(new MSHRBuffer(wPorts = 2))
+  val putBuf = Module(new PutBuffer)
+  val refillBuf = Module(new MSHRBuffer(wPorts = 3))
   val releaseBuf = Module(new MSHRBuffer(wPorts = 3))
 
   val prbq = Module(new ProbeQueue())
@@ -83,6 +84,7 @@ class Slice()(implicit p: Parameters) extends BaseSlice[OuterBundle] {
   mshrCtl.io.fromReqArb.status_s1 := reqArb.io.status_s1
   mshrCtl.io.resps.sinkC := sinkC.io.resp
   mshrCtl.io.resps.sinkD := refillUnit.io.resp
+  refillUnit.io.msInfo := mshrCtl.io.msInfo
   mshrCtl.io.resps.sourceC := sourceC.io.resp
   mshrCtl.io.nestedwb := mainPipe.io.nestedwb
   mshrCtl.io.aMergeTask := a_reqBuf.io.aMergeTask
@@ -103,11 +105,11 @@ class Slice()(implicit p: Parameters) extends BaseSlice[OuterBundle] {
   mainPipe.io.bufResp <> sinkC.io.bufResp
   mainPipe.io.toDS.rdata_s5 := dataStorage.io.rdata
   mainPipe.io.toDS.error_s5 := dataStorage.io.error
-  mainPipe.io.refillBufResp_s3.valid := RegNext(refillBuf.io.r.valid, false.B)
-  mainPipe.io.refillBufResp_s3.bits := refillBuf.io.resp.data
-  mainPipe.io.releaseBufResp_s3.valid := RegNext(releaseBuf.io.r.valid, false.B)
-  mainPipe.io.releaseBufResp_s3.bits := releaseBuf.io.resp.data
+  mainPipe.io.refillBufResp_s3 := refillBuf.io.resp.data
+  mainPipe.io.releaseBufResp_s3 := releaseBuf.io.resp.data
+  mainPipe.io.putBufResp_s3 := putBuf.io.resp.data
   mainPipe.io.fromReqArb.status_s1 := reqArb.io.status_s1
+  mainPipe.io.fromReqArb.steer_s2 := reqArb.io.steerToPipe_s2
   mainPipe.io.taskInfo_s1 <> reqArb.io.taskInfo_s1
 
   // priority: nested-ReleaseData / probeAckData [NEW] > mainPipe DS rdata [OLD]
@@ -120,8 +122,14 @@ class Slice()(implicit p: Parameters) extends BaseSlice[OuterBundle] {
   releaseBuf.io.w(1).bits.id := mshrCtl.io.releaseBufWriteId
   releaseBuf.io.w(2) <> mainPipe.io.releaseBufWrite
 
-  refillBuf.io.w(0) <> refillUnit.io.refillBufWrite
-  refillBuf.io.w(1) <> sinkC.io.refillBufWrite
+  refillBuf.io.w(0) := refillUnit.io.refillBufWrite
+  refillBuf.io.w(1) := sinkC.io.refillBufWrite
+  refillBuf.io.w(2) := mainPipe.io.refillBufWrite
+
+  /* Read and write put buffer */
+  sinkA.io.pBufState := putBuf.io.state
+  putBuf.io.w <> sinkA.io.putBufWrite
+  putBuf.io.r := reqArb.io.putBufRead_s2
 
   sourceC.io.in <> mainPipe.io.toSourceC
   sourceC.io.pipeStatusVec := reqArb.io.status_vec ++ mainPipe.io.status_vec_toC


### PR DESCRIPTION
## Summary

Complete the full PutFullData request handling flow for both TL-TL and TL-CHI, and refactor the DataStorage write control logic around a "data-source-oriented" design.

## Features

### Full PutFullData Request Flow Implementation

Add `coupledL2/PutBuffer` to provide data buffering, beat-to-block assembly, and data ownership decoupling for TileLink Put requests from the Matrix Accelerator. This allows the Put payload to stop traveling through MainPipe and the MSHR as part of `TaskBundle`.

When a Put request needs to allocate an MSHR, the PutData is migrated from PutBuffer to RefillBuffer. This allows RefillBuffer to be reused, reduces the required size of PutBuffer, and lets the subsequent request handling flow largely reuse the Acquire request handling flow, further reducing dedicated Put-specific control logic.

#### Theoretical Basis

This change is theoretically grounded. If we look closely at the Put request handling flow, PutFullData can be understood as an Acquire request that already carries the final new data.

PutFullData can be abstracted into two steps: "first acquire writable permission, then write the PutData."

It is easy to observe that "first acquire writable permission" is exactly the core task of Acquire-type requests. Therefore, PutFullData and Acquire-type requests can heavily reuse the same control flow for permission acquisition, miss handling, Probe handling, and replacement handling.

The only difference is that after an Acquire request obtains permission or data, it may eventually return data upstream or install refill data, while after PutFullData obtains the writable condition, it eventually writes the PutData carried by the request itself.

### Data-Source-Oriented DataStorage Write Control Logic Refactor

See the design document:

[https://www.yuque.com/jiangtianze-ynsvk/ktfb6x/so4ce2cuknm1azpz?singleDoc#文档](https://www.yuque.com/jiangtianze-ynsvk/ktfb6x/so4ce2cuknm1azpz?singleDoc#%E6%96%87%E6%A1%A3)

## Verification

✅ Passed the `coupledL2/openLLC` L2-L3 and matrix trace tests in `tl-test-new`.

✅ Added Put miss tests to the matrix trace, and they also passed successfully.