### PR TITLE
Add matrix AB ReadNoSnp path

### DIFF
--- a/src/main/scala/coupledL2/Common.scala
+++ b/src/main/scala/coupledL2/Common.scala
@@ -43,7 +43,9 @@ trait HasTLChannelBits { this: Bundle =>
 
 object MatrixInfo {
   def width = 2
-  def isMatrix(m: UInt): Bool = m(0)
+  def isAB(m: UInt): Bool = m === "b01".U
+  def isC(m: UInt): Bool = m === "b11".U
+  def isMatrix(m: UInt): Bool = isAB(m) || isC(m)
 }
 
 trait HasMatrixType {
@@ -136,6 +138,7 @@ class TaskBundle(implicit p: Parameters) extends L2Bundle
   val ameChannel = Option.when(enableMatrix)(UInt(4.W))
   val ameIndex = Option.when(enableMatrix)(UInt(7.W))
   val matrixTask = Option.when(enableMatrix)(Bool())
+  val matrixAB = Bool()
 
   // for TopDown Monitor (# TopDown)
   val reqSource = UInt(MemReqSource.reqSourceBits.W)

--- a/src/main/scala/coupledL2/CoupledL2.scala
+++ b/src/main/scala/coupledL2/CoupledL2.scala
@@ -42,6 +42,7 @@ trait HasCoupledL2Parameters {
   def enableClockGate = p(EnableL2ClockGate)
   def cacheParams = p(L2ParamKey)
   def enableMatrix = p(EnableMatrix)
+  def enableMatrixABNoSnpGet = p(EnableMatrixABNoSnpGet)
   def PrivateClintRange = cacheParams.PrivateClintRange
 
   def XLEN = 64

--- a/src/main/scala/coupledL2/Directory.scala
+++ b/src/main/scala/coupledL2/Directory.scala
@@ -38,6 +38,7 @@ class MetaEntry(implicit p: Parameters) extends L2Bundle {
   val accessed = Bool()
   val tagErr = Bool() // ECC error from L1/L3; DataCheck for CHI
   val dataErr = Bool()
+  val matrixAB = Bool()
 
   def =/=(entry: MetaEntry): Bool = {
     this.asUInt =/= entry.asUInt
@@ -51,7 +52,7 @@ object MetaEntry {
   }
   def apply(dirty: Bool, state: UInt, clients: UInt, alias: Option[UInt], prefetch: Bool = false.B,
             pfsrc: UInt = PfSource.NoWhere.id.U, accessed: Bool = false.B,
-            tagErr: Bool = false.B, dataErr: Bool = false.B
+            tagErr: Bool = false.B, dataErr: Bool = false.B, matrixAB: Bool = false.B
   )(implicit p: Parameters) = {
     val entry = Wire(new MetaEntry)
     entry.dirty := dirty
@@ -63,6 +64,7 @@ object MetaEntry {
     entry.accessed := accessed
     entry.tagErr := tagErr
     entry.dataErr := dataErr
+    entry.matrixAB := matrixAB
     entry
   }
 }

--- a/src/main/scala/coupledL2/L2Param.scala
+++ b/src/main/scala/coupledL2/L2Param.scala
@@ -30,6 +30,7 @@ import utility.{Code, MemReqSource, ReqSourceKey}
 case object EnableCHI extends Field[Boolean](false)
 case object EnableL2ClockGate extends Field[Boolean](true)
 case object EnableMatrix extends Field[Boolean](false)
+case object EnableMatrixABNoSnpGet extends Field[Boolean](false)
 
 // L1 Cache Params, used for TestTop generation
 case class L1Param

--- a/src/main/scala/coupledL2/SinkA.scala
+++ b/src/main/scala/coupledL2/SinkA.scala
@@ -103,6 +103,7 @@ class SinkA(implicit p: Parameters) extends L2Module {
     task.wayMask := 0.U(cacheParams.ways.W)
     task.reqSource := a.user.lift(utility.ReqSourceKey).getOrElse(MemReqSource.NoWhere.id.U)
     task.replTask := false.B
+    task.matrixAB := a.opcode === Get && MatrixInfo.isAB(matrixKey)
     task.matrixTask.foreach(_ := MatrixInfo.isMatrix(matrixKey))
     task.ameChannel.foreach(_ := a.user.lift(AmeChannelKey).getOrElse("b1000".U))
     task.ameIndex.foreach(_ := a.user.lift(AmeIndexKey).getOrElse(0.U))
@@ -147,6 +148,7 @@ class SinkA(implicit p: Parameters) extends L2Module {
     task.wayMask := 0.U(cacheParams.ways.W)
     task.reqSource := req.pfSource
     task.replTask := false.B
+    task.matrixAB := false.B
     task.matrixTask.foreach(_ := false.B)
     task.ameChannel.foreach(_ := 0.U)
     task.ameIndex.foreach(_ := 0.U)

--- a/src/main/scala/coupledL2/tl2chi/MSHR.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHR.scala
@@ -166,8 +166,9 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
   val req_get = req.opcode === Get
   val req_putfull = req.fromA && req.opcode === PutFullData
   val req_prefetch = req.opcode === Hint
+  val req_matrixABNoSnpGet = enableMatrixABNoSnpGet.B && req_get && req.matrixAB
 
-  val req_mayRepl = req_acquire || req_get || req_prefetch
+  val req_mayRepl = req_acquire || req_get || req_prefetch || req_putfull
 
   val req_chiOpcode = req.chiOpcode.get
 
@@ -387,6 +388,7 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
       req_cboClean                                       -> CleanShared,
       req_cboFlush                                       -> CleanInvalid,
       req_cboInval                                       -> MakeInvalid,
+      req_matrixABNoSnpGet                               -> ReadNoSnp,
       (req_acquirePerm || req_putfull)                   -> MakeUnique,
       req_needT                                          -> ReadUnique,
       req_needB /* Default */                            -> ReadNotSharedDirty
@@ -410,15 +412,15 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
     oa.expCompAck := Mux(
       release_valid2,
       afterIssueEbOrElse(req_released_chiOpcode === WriteEvictOrEvict, false.B),
-      !cmo_cbo
+      !cmo_cbo && !req_matrixABNoSnpGet
     )
-    oa.memAttr := MemAttr(
+    oa.memAttr := Mux(req_matrixABNoSnpGet, MemAttr(), MemAttr(
       cacheable = true.B,
       allocate = !release_valid2 || !isEvict && !cmo_cbo,
       device = false.B,
       ewa = true.B
-    )
-    oa.snpAttr := true.B
+    ))
+    oa.snpAttr := !req_matrixABNoSnpGet
     oa.lpIDWithPadding := 0.U
     oa.excl := false.B
     oa.snoopMe := false.B
@@ -676,7 +678,8 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
       clients = meta.clients & Fill(clientBits, !snpToN),
       alias = meta.alias, //[Alias] Keep alias bits unchanged
       prefetch = !snpToN && meta_pft,
-      accessed = !snpToN && meta.accessed
+      accessed = !snpToN && meta.accessed,
+      matrixAB = !snpToN && !tagErr && meta.matrixAB
     )
     mp_probeack.metaWen := !req.snpHitReleaseToInval
     mp_probeack.tagWen := false.B
@@ -806,7 +809,8 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
       alias = Some(aliasFinal),
       prefetch = req_prefetch || dirResult.hit && meta_pft,
       pfsrc = PfSource.fromMemReqSource(req.reqSource),
-      accessed = req_putfull || req_acquire || req_get
+      accessed = req_putfull || req_acquire || req_get,
+      matrixAB = req_matrixABNoSnpGet
     )
     mp_grant.metaWen := !cmo_cbo && !denied
     mp_grant.tagWen := !cmo_cbo && !dirResult.hit && !denied
@@ -818,6 +822,9 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
     mp_grant.wayMask := 0.U(cacheParams.ways.W)
     mp_grant.mshrRetry := !state.s_retry
     mp_grant.reqSource := 0.U(MemReqSource.reqSourceBits.W)
+    mp_grant.ameChannel.foreach(_ := req.ameChannel.getOrElse(0.U))
+    mp_grant.ameIndex.foreach(_ := req.ameIndex.getOrElse(0.U))
+    mp_grant.matrixTask.foreach(_ := req.matrixTask.getOrElse(false.B))
 
     // Add merge grant task for Acquire and late Prefetch
     mp_grant.mergeA := mergeA || io.aMergeTask.valid
@@ -1258,6 +1265,8 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
 
   // replay
   val replResp = io.replResp.bits
+  val replRespSilentMatrixAB = enableMatrixABNoSnpGet.B &&
+    replResp.meta.matrixAB && !replResp.meta.dirty && !replResp.meta.clients.orR
   when (io.replResp.valid && replResp.retry) {
     state.s_refill := false.B
     state.s_retry := false.B
@@ -1280,7 +1289,7 @@ class MSHR(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
     // 2. the same way, just release as normal (only now we set s_release)
     // 3. differet way, we need to update meta and release that way
     // if meta has client, rprobe client
-    when (replResp.meta.state =/= INVALID) {
+    when (replResp.meta.state =/= INVALID && !replRespSilentMatrixAB) {
       // set release flags
       state.s_release := false.B
       state.w_releaseack := false.B

--- a/src/main/scala/coupledL2/tl2chi/MainPipe.scala
+++ b/src/main/scala/coupledL2/tl2chi/MainPipe.scala
@@ -166,6 +166,7 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
   val req_acquireBlock_s3       = sinkA_req_s3 && req_s3.opcode === AcquireBlock
   val req_prefetch_s3           = sinkA_req_s3 && req_s3.opcode === Hint
   val req_get_s3                = sinkA_req_s3 && req_s3.opcode === Get
+  val req_matrixABNoSnpGet_s3   = enableMatrixABNoSnpGet.B && req_get_s3 && req_s3.matrixAB
   val req_putfull_s3            = sinkA_req_s3 && req_s3.opcode === PutFullData
   val req_cbo_clean_s3          = sinkA_req_s3 && req_s3.opcode === CBOClean
   val req_cbo_flush_s3          = sinkA_req_s3 && req_s3.opcode === CBOFlush && !cmoHitInvalid
@@ -255,7 +256,7 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
     req_cbo_inval_s3 && (isValid(meta_s3.state))
   )
   val need_cmoresp_s3_a = cmo_cbo_s3
-  val need_compack_s3_a = !cmo_cbo_s3
+  val need_compack_s3_a = !cmo_cbo_s3 && !req_matrixABNoSnpGet_s3
 
   val need_mshr_s3_a = need_acquire_s3_a || need_probe_s3_a || cache_alias
   
@@ -573,7 +574,8 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
     alias = Some(metaW_s3_a_alias),
     accessed = true.B,
     tagErr = meta_s3.tagErr,
-    dataErr = meta_s3.dataErr
+    dataErr = meta_s3.dataErr,
+    matrixAB = false.B
   )
   val metaW_s3_b = Mux(isSnpToN(req_s3.chiOpcode.get), MetaEntry(),
     MetaEntry(
@@ -583,7 +585,8 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
       alias = meta_s3.alias,
       accessed = meta_s3.accessed,
       tagErr = meta_s3.tagErr,
-      dataErr = meta_s3.dataErr
+      dataErr = meta_s3.dataErr,
+      matrixAB = meta_s3.matrixAB
     )
   )
   val metaW_s3_c = MetaEntry(
@@ -593,7 +596,8 @@ class MainPipe(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes
     alias = meta_s3.alias,
     accessed = meta_s3.accessed,
     tagErr = Mux(wen_c, req_s3.denied, meta_s3.tagErr),
-    dataErr = Mux(wen_c, req_s3.corrupt, meta_s3.dataErr) // update error when write DS
+    dataErr = Mux(wen_c, req_s3.corrupt, meta_s3.dataErr), // update error when write DS
+    matrixAB = meta_s3.matrixAB && !wen_c
   )
   // use merge_meta if mergeA
   val metaW_s3_mshr = WireInit(Mux(req_s3.mergeA, req_s3.aMergeTask.meta, req_s3.meta))

--- a/src/main/scala/coupledL2/tl2tl/MainPipe.scala
+++ b/src/main/scala/coupledL2/tl2tl/MainPipe.scala
@@ -260,6 +260,7 @@ class MainPipe(implicit p: Parameters) extends L2Module with HasPerfEvents {
   ms_task.ameChannel.foreach(_ := req_s3.ameChannel.getOrElse(0.U))
   ms_task.ameIndex.foreach(_ := req_s3.ameIndex.getOrElse(0.U))
   ms_task.matrixTask.foreach(_ := req_s3.matrixTask.getOrElse(false.B))
+  ms_task.matrixAB         := req_s3.matrixAB
   /* ======== Resps to SinkA/B/C Reqs ======== */
   val sink_resp_s3 = WireInit(0.U.asTypeOf(Valid(new TaskBundle))) // resp for sinkA/B/C request that does not need to alloc mshr
   val sink_resp_s3_a_promoteT = dirResult_s3.hit && isT(meta_s3.state)
@@ -385,7 +386,8 @@ class MainPipe(implicit p: Parameters) extends L2Module with HasPerfEvents {
     alias = Some(metaW_s3_a_alias),
     accessed = true.B,
     tagErr = meta_s3.tagErr,
-    dataErr = meta_s3.dataErr
+    dataErr = meta_s3.dataErr,
+    matrixAB = false.B
   )
   val metaW_s3_b = Mux(req_s3.param === toN, MetaEntry(),
     MetaEntry(
@@ -394,7 +396,8 @@ class MainPipe(implicit p: Parameters) extends L2Module with HasPerfEvents {
       clients = meta_s3.clients,
       alias = meta_s3.alias,
       tagErr = meta_s3.tagErr,
-      dataErr = meta_s3.dataErr
+      dataErr = meta_s3.dataErr,
+      matrixAB = meta_s3.matrixAB
     )
   )
 
@@ -405,7 +408,8 @@ class MainPipe(implicit p: Parameters) extends L2Module with HasPerfEvents {
     alias = meta_s3.alias,
     accessed = meta_s3.accessed,
     tagErr = Mux(wen_c, req_s3.denied, meta_s3.tagErr),
-    dataErr = Mux(wen_c, req_s3.corrupt, meta_s3.dataErr) // update error when write DS
+    dataErr = Mux(wen_c, req_s3.corrupt, meta_s3.dataErr), // update error when write DS
+    matrixAB = meta_s3.matrixAB && !wen_c
   )
   // use merge_meta if mergeA
   val metaW_s3_mshr = WireInit(Mux(req_s3.mergeA, req_s3.aMergeTask.meta, req_s3.meta))


### PR DESCRIPTION
## Summary

This PR adds support for routing Matrix A/B `Get` requests through the CHI `ReadNoSnp` path when enabled by configuration.

The feature is controlled by a new `EnableMatrixABNoSnpGet` parameter. When enabled, Matrix A/B reads are marked in the L2 request path and later converted to `ReadNoSnp` on the TL-CHI side.

## Changes

- Added `EnableMatrixABNoSnpGet` as a configurable L2 parameter.
- Added Matrix A/B identification helpers.
- Added a `matrixAB` bit to `TaskBundle` and `MetaEntry`.
- Marked Matrix A/B `Get` requests in `SinkA`.
- Converted eligible Matrix A/B `Get` requests to CHI `ReadNoSnp` in `tl2chi/MSHR`.
- Disabled unnecessary CompAck/snoop attributes for Matrix A/B `ReadNoSnp`.
- Preserved `matrixAB` metadata through MainPipe metadata updates.
- Added silent replacement handling for clean Matrix A/B `ReadNoSnp` cachelines.
- Fixed the TL-to-TL MainPipe path to initialize and preserve the new `matrixAB` field.

## Validation

- `coupledL2-test-matrix-trace`: passed
  - Trace summary: `sent{R/W/E}=160/32/0, recv{R/W/E}=160/32/0`
  - Finalized at cycle `2222`

This PR is expected to be used together with the corresponding OpenLLC PR that adds LLC-side `ReadNoSnp` handling.